### PR TITLE
Fix exports from GitHub Enterprise Server, and validate the version when starting an export

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,33 @@
 
 A [GitHub CLI](https://cli.github.com/) [extension](https://cli.github.com/manual/gh_extension) for migrating [GitHub Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects) between:
 
-* different GitHub products (e.g. GitHub Enterprise Server to GitHub.com)
-* organizations using the same GitHub product (e.g. classic GitHub.com organization to [Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) organization).
-* users using the same GitHub product
+- different GitHub products (e.g. GitHub Enterprise Server v3.8+ to GitHub.com, or vice versa)
+- organizations using the same GitHub product (e.g. classic GitHub.com organization to [Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) organization).
+- users using the same GitHub product
 
 ## Limitations
 
+### Classic projects are not supported
+
+This tool can't migrate so-called classic Projects - only the newer version of [GitHub Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects).
+
+Classic Projects can be migrated with [GitHub Enterprise Importer](https://docs.github.com/en/migrations/using-github-enterprise-importer) or [`ghe-migrator`](https://docs.github.com/en/enterprise-cloud@latest/migrations/using-ghe-migrator/about-ghe-migrator).
+
+### Only GitHub Enterprise Server 3.8 onwards is supported
+
+[GitHub Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects) is only available in GitHub Enterprise Server 3.8 onwards, so this tool will only work with 3.8 onwards for exports and imports.
+
+### Not all data is migrated
+
 The following data is not migrated and will be skipped:
 
-* Views
-* The order of project items displayed in your views
-* Workflows
-* Iteration custom fields
-* Draft issues' assignees
+- Views
+- The order of project items displayed in your views
+- Workflows
+- Iteration custom fields
+- Draft issues' assignees
+
+### Draft issues will show the person running the migration as the author
 
 Migrated draft issues will show as being created by the person who ran the migration at the time they ran the migration. A note will be prepended to the body with original author login and timestamp.
 
@@ -66,8 +80,8 @@ gh migrate-project export \
 
 When the export finishes, you'll have two files written to your current directory:
 
-* `project.json`: The raw data of your project and all of its project items
-* `repository-mappings.csv`: A repository mappings CSV template that you need to fill out with the names of your repositories in the migration target
+- `project.json`: The raw data of your project and all of its project items
+- `repository-mappings.csv`: A repository mappings CSV template that you need to fill out with the names of your repositories in the migration target
 
 ### Step 4. Complete the repository mappings template
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "commander": "^11.1.0",
         "octokit": "^3.1.1",
         "prompt-sync": "^4.2.0",
+        "semver": "^7.5.4",
         "undici": "^5.26.4",
         "winston": "^3.11.0"
       },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "commander": "^11.1.0",
     "octokit": "^3.1.1",
     "prompt-sync": "^4.2.0",
+    "semver": "^7.5.4",
     "undici": "^5.26.4",
     "winston": "^3.11.0"
   },

--- a/src/github-products.ts
+++ b/src/github-products.ts
@@ -1,0 +1,61 @@
+import type { Octokit } from 'octokit';
+import { Endpoints } from '@octokit/types';
+import semver from 'semver';
+
+type DotcomMetaResponse = Endpoints['GET /meta']['response'];
+
+// Octokit's default types target GitHub.com where there is no `installed_version` returned
+// from this API. We construct our own type which includes this.
+type GhesMetaResponse = DotcomMetaResponse & {
+  data: {
+    installed_version: string;
+  };
+};
+
+// TODO: Check what GHES version supports Projects
+export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION = '3.8.0';
+
+export const isSupportedGitHubEnterpriseServerVersion = (version: string) =>
+  semver.gte(version, MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION);
+
+export const getGitHubProductInformation = async (
+  octokit: Octokit,
+): Promise<
+  | {
+      isGitHubEnterpriseServer: true;
+      gitHubEnterpriseServerVersion: string;
+    }
+  | {
+      isGitHubEnterpriseServer: false;
+      gitHubEnterpriseServerVersion: undefined;
+    }
+> => {
+  const isGitHubEnterpriseServer = isGitHubEnterpriseServerBaseUrl(
+    octokit.request.endpoint.DEFAULTS.baseUrl,
+  );
+
+  if (isGitHubEnterpriseServer) {
+    const gitHubEnterpriseServerVersion = await getGitHubEnterpriseServerVersion(octokit);
+
+    return {
+      isGitHubEnterpriseServer,
+      gitHubEnterpriseServerVersion,
+    };
+  } else {
+    return {
+      isGitHubEnterpriseServer,
+      gitHubEnterpriseServerVersion: undefined,
+    };
+  }
+};
+
+const isGitHubEnterpriseServerBaseUrl = (baseUrl: string): boolean =>
+  baseUrl !== 'https://api.github.com';
+
+const getGitHubEnterpriseServerVersion = async (octokit: Octokit): Promise<string> => {
+  const {
+    data: { installed_version },
+  } = (await octokit.rest.meta.get()) as GhesMetaResponse;
+
+  return installed_version;
+};

--- a/src/graphql-types.ts
+++ b/src/graphql-types.ts
@@ -60,8 +60,8 @@ export interface Project {
       options?: Array<{
         id: string;
         name: string;
-        description: string;
-        color: ProjectSingleSelectFieldOptionColor;
+        description?: string;
+        color?: ProjectSingleSelectFieldOptionColor;
       }>;
     }>;
     totalCount: number;


### PR DESCRIPTION
In https://github.com/timrogers/gh-migrate-project/discussions/67, @harvi2048 spotted that exports from GitHub Enterprise Server  (GHES)didn't work (in their case from 3.9.5) because we try to query some fields that don't exist in _any current_ GHES versions - namely, the `description` and `color` on "Single select" custom fields' options.

This fixes that by checking what environment we are exporting from at the beginning of the process, and then conditionally including or excluding those fields from the GraphQL query based on the version. 

We will only query those fields if we are exporting from GitHub.com, and not from any GitHub Enterprise Server version. Later down the line, these fields will come to GHES, and we'd expect to be able to relax this requirement.

These "old" exports are still importable on GitHub.com.

As part of this change, we also check that we are exporting from a supported GitHub product - at this time - either GitHub.com or any GHES version with Projects (that is, 3.7+) - and fail fast if not.