### PR TITLE
Explicitly only support imports to GitHub.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 A [GitHub CLI](https://cli.github.com/) [extension](https://cli.github.com/manual/gh_extension) for migrating [GitHub Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects) between:
 
-- different GitHub products (e.g. GitHub Enterprise Server v3.8+ to GitHub.com, or vice versa)
-- organizations using the same GitHub product (e.g. classic GitHub.com organization to [Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) organization).
-- users using the same GitHub product
+- GitHub Enterprise Server v3.7+ and GitHub.com
+- owners (organizations or users) on GitHub.com (e.g. from a classic GitHub.com organization to [Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) organization)
 
 ## Limitations
 
@@ -14,9 +13,15 @@ This tool can't migrate so-called classic Projects - only the newer version of [
 
 Classic Projects can be migrated with [GitHub Enterprise Importer](https://docs.github.com/en/migrations/using-github-enterprise-importer) or [`ghe-migrator`](https://docs.github.com/en/enterprise-cloud@latest/migrations/using-ghe-migrator/about-ghe-migrator).
 
-### Only GitHub Enterprise Server 3.8 onwards is supported
+### Exports are supported from GitHub Enterprise Server, but only 3.7 onwards
 
-[GitHub Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects) is only available in GitHub Enterprise Server 3.8 onwards, so this tool will only work with 3.8 onwards for exports and imports.
+[GitHub Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects) is only available in GitHub Enterprise Server 3.7 onwards, so this tool will only work with 3.7 onwards for exports.
+
+### Once data has been exported, it can only be imported to GitHub.com
+
+At this time, imports to GitHub Enterprise Server are not supported, so you won't be able to use this tool to move between Enterprise Server instances or from GitHub.com to your own Enterprise Server.
+
+This will be fixable with some work, but it's complicated because of GraphQL API differences between GitHub.com and current Enterprise Server versions.
 
 ### Not all data is migrated
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -10,7 +10,7 @@ import { createOctokit } from '../octokit.js';
 import { type Project, type ProjectItem } from '../graphql-types.js';
 import { getReferencedRepositories } from '../project-items.js';
 import {
-  MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION,
+  MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION_FOR_EXPORTS,
   getGitHubProductInformation,
 } from '../github-products.js';
 
@@ -445,11 +445,11 @@ command
         if (
           semver.lte(
             gitHubEnterpriseServerVersion,
-            MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION,
+            MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION_FOR_EXPORTS,
           )
         ) {
           throw new Error(
-            `You are trying to export from GitHub Enterprise Server ${gitHubEnterpriseServerVersion}, but only ${MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION} onwards is supported.`,
+            `You are trying to export from GitHub Enterprise Server ${gitHubEnterpriseServerVersion}, but only ${MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION_FOR_EXPORTS} onwards is supported.`,
           );
         }
 

--- a/src/github-products.ts
+++ b/src/github-products.ts
@@ -12,11 +12,10 @@ type GhesMetaResponse = DotcomMetaResponse & {
   };
 };
 
-// TODO: Check what GHES version supports Projects
-export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION = '3.8.0';
+export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION_FOR_EXPORTS = '3.7.0';
 
-export const isSupportedGitHubEnterpriseServerVersion = (version: string) =>
-  semver.gte(version, MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION);
+export const isSupportedGitHubEnterpriseServerVersionForExports = (version: string) =>
+  semver.gte(version, MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION_FOR_EXPORTS);
 
 export const getGitHubProductInformation = async (
   octokit: Octokit,

--- a/src/graphql-types.ts
+++ b/src/graphql-types.ts
@@ -36,14 +36,14 @@ export enum ProjectItemFieldValueType {
 }
 
 export enum ProjectSingleSelectFieldOptionColor {
-  BLUE,
-  GRAY,
-  GREEN,
-  ORANGE,
-  PINK,
-  PURPLE,
-  RED,
-  YELLOW,
+  BLUE = 'BLUE',
+  GRAY = 'GRAY',
+  GREEN = 'GREEN',
+  ORANGE = 'ORANGE',
+  PINK = 'PINK',
+  PURPLE = 'PURPLE',
+  RED = 'RED',
+  YELLOW = 'YELLOW',
 }
 
 export interface Project {


### PR DESCRIPTION
This tool was originally designed to allow exports and imports from/to GitHub.com and GitHub Enterprise Server, but this wasn't fully tested, and the reality is complicated!

Imports to GitHub Enterprise Server are not working properly, and fixing this will require some work due to API differences.

Instead, this change makes the situation clear: only imports to GitHub.com are supported, although we will endeavour to accept exports from any GHES version - which means, for example, filling in some data that has been mandatory since older versions.

As a follow up, we can look at fixing support for GHES imports.