### PR TITLE
Avoid outputting GitHub tokens from environment variables in CLI help output

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -355,7 +355,6 @@ command
   .option(
     '--access-token <access_token>',
     'The access token used to interact with the GitHub API. This can also be set using the EXPORT_GITHUB_TOKEN environment variable.',
-    process.env.EXPORT_GITHUB_TOKEN,
   )
   .option(
     '--base-url <base_url>',
@@ -398,7 +397,7 @@ command
   .action(
     actionRunner(async (opts: Arguments) => {
       const {
-        accessToken,
+        accessToken: accessTokenFromArguments,
         baseUrl,
         projectNumber,
         projectOutputPath,
@@ -408,6 +407,8 @@ command
         repositoryMappingsOutputPath,
         verbose,
       } = opts;
+
+      const accessToken = accessTokenFromArguments || process.env.EXPORT_GITHUB_TOKEN;
 
       if (!accessToken) {
         throw new Error(

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -677,7 +677,6 @@ command
   .option(
     '--access-token <access_token>',
     'The access token used to interact with the GitHub API. This can also be set using the IMPORT_GITHUB_TOKEN environment variable.',
-    process.env.IMPORT_GITHUB_TOKEN,
   )
   .option(
     '--base-url <base_url>',
@@ -717,7 +716,7 @@ command
   .action(
     actionRunner(async (opts: Arguments) => {
       const {
-        accessToken,
+        accessToken: accessTokenFromArguments,
         baseUrl,
         inputPath,
         projectOwner,
@@ -727,6 +726,8 @@ command
         repositoryMappingsPath,
         verbose,
       } = opts;
+
+      const accessToken = accessTokenFromArguments || process.env.IMPORT_GITHUB_TOKEN;
 
       if (!accessToken) {
         throw new Error(


### PR DESCRIPTION
When calling any of our CLI commands with `--help`, if the GitHub access token is set using an environment variable, its value is included in the help output in plain text. This isn't desirable.

This changes our implementation of "environment variable as default" so that the environment variable is still used, but it isn't displayed as the default in help output.