### PR TITLE
Use Node.js v18.x in packaged binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Migrate GitHub projects (https://docs.github.com/en/issues/planning-and-tracking-with-projects) between GitHub products, organizations and users",
   "homepage": "https://github.com/timrogers/gh-migrate-project",
   "scripts": {
-    "package": "node build.js && npx pkg dist/migrate-project.cjs --out-path bin",
+    "package": "node build.js && npx pkg dist/migrate-project.cjs --out-path bin --targets node18-linux-x64,node18-macos-x64,node18-win-x64",
     "lint": "eslint . --ext .ts",
     "lint-and-fix": "eslint . --ext .ts --fix",
     "dev": "npx ts-node --esm src/index.ts"


### PR DESCRIPTION
This updates packaged binaries to use a more modern version of Node.js, v18.

Based on https://github.com/vercel/pkg/discussions/1972, it doesn't seem like truly current versions are supported by `pkg`, but this will at least allow us to use Node.js v17's `readline/promises` module, which is required by #89.