### PR TITLE
When an error is caught at the command level, log its stack trace

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,7 @@ export const presentError = (e: unknown): string => {
 
 const actionErrorHandler = (error: Error): void => {
   console.error(chalk.red(error.message));
+  console.error(error.stack);
   process.exit(1);
 };
 


### PR DESCRIPTION
Each of our commands' handlers is wrapped with an error handler, `actionErrorHandler`, which logs the error message in red and then exits with status code `1`.

An error's message is not necessarily super helpful - as seen with the `Cannot read properties of null (reading '__typename')` error in #85. This additionally logs the stack trace, giving more context on what went wrong and where.