### PR TITLE
feat: add defaults for the `import` command's `--input-path` and `--repository-mappings-path` arguments

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -691,10 +691,12 @@ command
   .requiredOption(
     '--input-path <input_path>',
     'The path to the exported project data. This will be the --project-output-path argument passed to the `export` command, which defaults to `project.json`.',
+    'project.json',
   )
   .requiredOption(
     '--repository-mappings-path <repository_mappings_path>',
     'The path to your completed repository mappings file. This will be the --repository-mappings-output-path argument passed to the `export` command, which defaults to `repository-mappings.csv`.',
+    'repository-mappings.csv',
   )
   .option(
     '--project-title <project_name>',


### PR DESCRIPTION
For importing, setting defaults for the `--input-path` and `--repository-mappings-path` parameters.

I would imagine most people running this are going to run the export in a folder, update the repo mappings, and then run the import. Setting defaults saves some typing/copy+pasting 😄 

And also, the `gh migrate-project --help` already mentioned defaults (I realize it was mentioning the _default for the export command_, but we might as well default it for the import command too. 

>   `--input-path <input_path>` The path to the exported project data. This will be the --project-output-path argument passed to the `export` command, **which defaults to `project.json`.**
>   `--repository-mappings-path <repository_mappings_path>`  The path to your completed repository mappings file. This will be the --repository-mappings-output-path argument passed to the `export` command, **which defaults to `repository-mappings.csv`.**
