### PR TITLE
Check for updates to the extension when running the `export` or `import` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ gh migrate-project export \
     # OPTIONAL: Emit detailed, verbose logs (off by default)
     --verbose \
     # OPTIONAL: Disable anonymous telemetry that gives the maintainers of this tool basic information about real-world usage.
-    --disable-telemetry
+    --disable-telemetry \
+    # OPTIONAL: Skip automatic check for updates to this tool
+    --skip-update-check
 ```
 
 When the export finishes, you'll have two files written to your current directory:
@@ -141,7 +143,9 @@ gh migrate-project import \
     # OPTIONAL: Emit detailed, verbose logs (off by default)
     --verbose \
     # OPTIONAL: Disable anonymous telemetry that gives the maintainers of this tool basic information about real-world usage.
-    --disable-telemetry
+    --disable-telemetry \
+    # OPTIONAL: Skip automatic check for updates to this tool
+    --skip-update-check
 ```
 
 Near the start of the import, the tool will ask you to manually set up your options for the "Status" field. It will explain exactly what to do, and will validate that you've correctly copied the options from your migration source.

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -8,7 +8,7 @@ import { Logger } from './logger';
 const OctokitWithPaginateGraphql = Octokit.plugin(paginateGraphql);
 
 export const createOctokit = (
-  token: string,
+  token: string | undefined,
   baseUrl: string,
   proxyUrl: string | undefined,
   logger: Logger,


### PR DESCRIPTION
This adds a new automated update check when the extension is run.

Unless the `--skip-update-check` flag is set, we'll fetch the latest extension version using the GitHub API and check that you're up to date.

If you're running an old version, we'll let you know what the latest version is and explain how to update.