### PR TITLE
Gracefully handle missing a missing issue/PR when importing a project item

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -5,7 +5,6 @@ import * as readline from 'node:readline/promises';
 import { type Octokit } from 'octokit';
 import { parse } from '@fast-csv/parse';
 import boxen from 'boxen';
-import { GraphqlResponseError } from '@octokit/graphql';
 import semver from 'semver';
 import { PostHog } from 'posthog-node';
 
@@ -218,10 +217,7 @@ const getIssueOrPullRequestByRepositoryAndNumber = async ({
 
     return response.repository.issueOrPullRequest;
   } catch (e) {
-    if (
-      e instanceof GraphqlResponseError &&
-      e.message.startsWith('Could not resolve to an issue or pull request')
-    ) {
+    if (e.message.includes('Could not resolve to an issue or pull request')) {
       return null;
     } else {
       throw e;


### PR DESCRIPTION
When trying to import a project item where the pull request or issue is missing, this is intended to log a warning, but currently, it causes the entire application to crash.

This fixes it, so a warning is logged and we move on to importing the next project item.

Fixes #227.