### PR TITLE
Add `--skip-certificate-verification` option to support proxies and GitHub Enterprise Server instances with untrusted certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ gh migrate-project export \
     --verbose \
     # OPTIONAL: Disable anonymous telemetry that gives the maintainers of this tool basic information about real-world usage.
     --disable-telemetry \
+    # OPTIONAL: Skip verification of SSL certificates when connecting to GitHub. You may need to use this option if connecting to a GitHub Enterprise Server instance with a self-signed certificate, or if you have configured a proxy.
+    --skip-certificate-verification \
     # OPTIONAL: Skip automatic check for updates to this tool
     --skip-update-check
 ```
@@ -141,6 +143,8 @@ gh migrate-project import \
     --verbose \
     # OPTIONAL: Disable anonymous telemetry that gives the maintainers of this tool basic information about real-world usage.
     --disable-telemetry \
+    # OPTIONAL: Skip verification of SSL certificates when connecting to GitHub. You may need to use this option if connecting to a GitHub Enterprise Server instance with a self-signed certificate, or if you have configured a proxy.
+    --skip-certificate-verification \
     # OPTIONAL: Skip automatic check for updates to this tool
     --skip-update-check
 ```
@@ -151,12 +155,7 @@ Once you've set up the "Status" field, your project will be imported. Watch out 
 
 ### Troubleshooting
 
-If you run into SSL connection errors and you are unable to set your proxy settings with the `--proxy-url` parameter, you can set the `NODE_TLS_REJECT_UNAUTHORIZED=0` environment variable to bypass:
-
-```
-export NODE_TLS_REJECT_UNAUTHORIZED=0 # setting an environment variable in bash
-$Env:NODE_TLS_REJECT_UNAUTHORIZED = 0 # setting an environment variable in PowerShell
-```
+If you are connecting to a GitHub Enterprise Server instance with a self-signed certificate, or if you have configured a proxy, you may experience SSL/TLS related errors. You can skip certificate verification with the `--skip-certificate-verification` argument.
 
 ## Telemetry
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -35,6 +35,7 @@ interface Arguments {
   projectOwnerType: ProjectOwnerType;
   projectNumber: number;
   proxyUrl: string | undefined;
+  skipCertificateVerification: boolean;
   skipUpdateCheck: boolean;
   verbose: boolean;
 }
@@ -405,6 +406,11 @@ command
     false,
   )
   .option('--skip-update-check', 'Skip automatic check for updates to this tool', false)
+  .option(
+    '--skip-certificate-verification',
+    'Skip verification of SSL certificates when connecting to GitHub. You may need to use this option if connecting to a GitHub Enterprise Server instance with a self-signed certificate, or if you have configured a proxy.',
+    false,
+  )
   .action(
     actionRunner(async (opts: Arguments) => {
       const {
@@ -417,11 +423,14 @@ command
         projectOwnerType,
         proxyUrl,
         repositoryMappingsOutputPath,
+        skipCertificateVerification,
         skipUpdateCheck,
         verbose,
       } = opts;
 
       const logger = createLogger(verbose);
+
+      if (skipCertificateVerification) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
       if (!skipUpdateCheck) checkForUpdates(proxyUrl, logger);
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -432,7 +432,7 @@ command
 
       if (skipCertificateVerification) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
-      if (proxyUrl && !skipCertificateVerification) {
+      if (proxyUrl && process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0') {
         logger.warn(
           'You have specified a proxy URL, but have not disabled certificate verification. This is likely to cause SSL connection errors. If you encounter SSL errors, make sure you are on a trusted network, and then try again with the --skip-certificate-verification flag.',
         );

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -432,6 +432,12 @@ command
 
       if (skipCertificateVerification) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
+      if (proxyUrl && !skipCertificateVerification) {
+        logger.warn(
+          'You have specified a proxy URL, but have not disabled certificate verification. This is likely to cause SSL connection errors. If you encounter SSL errors, make sure you are on a trusted network, and then try again with the --skip-certificate-verification flag.',
+        );
+      }
+
       if (!skipUpdateCheck) checkForUpdates(proxyUrl, logger);
 
       const posthog = new PostHog(POSTHOG_API_KEY, {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -758,6 +758,12 @@ command
 
       if (skipCertificateVerification) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
+      if (proxyUrl && !skipCertificateVerification) {
+        logger.warn(
+          'You have specified a proxy URL, but have not disabled certificate verification. This is likely to cause SSL connection errors. If you encounter SSL errors, make sure you are on a trusted network, and then try again with the --skip-certificate-verification flag.',
+        );
+      }
+
       if (!skipUpdateCheck) checkForUpdates(proxyUrl, logger);
 
       const posthog = new PostHog(POSTHOG_API_KEY, {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -47,6 +47,7 @@ interface Arguments {
   projectTitle?: string;
   proxyUrl: string | undefined;
   repositoryMappingsPath: string;
+  skipCertificateVerification: boolean;
   skipUpdateCheck: boolean;
   verbose: boolean;
 }
@@ -731,6 +732,11 @@ command
       .default(ProjectOwnerType.Organization),
   )
   .option('--skip-update-check', 'Skip automatic check for updates to this tool', false)
+  .option(
+    '--skip-certificate-verification',
+    'Skip verification of SSL certificates when connecting to GitHub. You may need to use this option if connecting to a GitHub Enterprise Server instance with a self-signed certificate, or if you have configured a proxy.',
+    false,
+  )
   .action(
     actionRunner(async (opts: Arguments) => {
       const {
@@ -743,11 +749,14 @@ command
         projectTitle,
         proxyUrl,
         repositoryMappingsPath,
+        skipCertificateVerification,
         skipUpdateCheck,
         verbose,
       } = opts;
 
       const logger = createLogger(verbose);
+
+      if (skipCertificateVerification) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
       if (!skipUpdateCheck) checkForUpdates(proxyUrl, logger);
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -758,7 +758,7 @@ command
 
       if (skipCertificateVerification) process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
-      if (proxyUrl && !skipCertificateVerification) {
+      if (proxyUrl && process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0') {
         logger.warn(
           'You have specified a proxy URL, but have not disabled certificate verification. This is likely to cause SSL connection errors. If you encounter SSL errors, make sure you are on a trusted network, and then try again with the --skip-certificate-verification flag.',
         );


### PR DESCRIPTION
This adds a new `--skip-certificate-verification` option to the `export` and `import` commands, which allows certificate verification to be skipped when connecting to GitHub for the export or import.

This is likely to be useful when connecting through a proxy, or to a GitHub Enterprise Server instance with an untrusted (e.g. self-signed) certificate, and it replaces setting the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable, which is currently recommended in the readme.

I've also added a helpful warning when a proxy is specified but this argument is not set, warning that you're likely to have connection problems.