### PR TITLE
feat: drop support for GitHub Enterprise Server v3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,47 +303,6 @@ jobs:
         with:
           name: linux-outputs-ghes-311
           path: output
-  end_to_end_tests_linux_ghes_310:
-    name: Run end to end tests (GitHub.com to GHES v3.10 on Linux)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.0.3
-        with:
-          node-version: 20.x
-          cache: 'npm'
-      - run: npm ci
-      - name: Generate binaries for macOS, Linux and Windows
-        run: npm run package
-      - name: Rename Linux binary to conform to GitHub CLI extension rules
-        run: mv bin/migrate-project-linux bin/gh-migrate-project-linux-amd64
-      - name: Create `output` directory
-        run: mkdir output
-      - name: Make Linux binary executable
-        run: chmod +x bin/gh-migrate-project-linux-amd64
-      - name: Export a project from GitHub.com
-        run: ./bin/gh-migrate-project-linux-amd64 export --project-owner gh-migrate-project-sandbox --project-number 1026 --disable-telemetry
-        env:
-          EXPORT_GITHUB_TOKEN: ${{ secrets.GH_MIGRATE_PROJECT_SANDBOX_TOKEN }}
-      - name: Copy outputs to output/ directory
-        run: cp project.json output/ && cp repository-mappings.csv output/
-      - name: Print outputted project data
-        run: cat project.json
-      - name: Print repository mappings template
-        run: cat repository-mappings.csv
-      - name: Fill in repository mappings template
-        run: |
-          echo "source_repository,target_repository
-          gh-migrate-project-sandbox/initial-repository,gh-migrate-project-sandbox/initial-repository" > completed-repository-mappings.csv
-      - name: Import project to GHES
-        run: ./bin/gh-migrate-project-linux-amd64 import --input-path project.json --repository-mappings-path completed-repository-mappings.csv --project-owner gh-migrate-project-sandbox --disable-telemetry --base-url ${{ secrets.GHES_310_BASE_URL }}
-        env:
-          IMPORT_GITHUB_TOKEN: ${{ secrets.GHES_310_ACCESS_TOKEN }}
-      - name: Upload outputs as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-outputs-ghes-310
-          path: output
   package:
     name: Package binaries
     runs-on: ubuntu-latest
@@ -394,7 +353,6 @@ jobs:
         'end_to_end_tests_linux_ghes_313',
         'end_to_end_tests_linux_ghes_312',
         'end_to_end_tests_linux_ghes_311',
-        'end_to_end_tests_linux_ghes_310',
         'end_to_end_tests_windows',
         'end_to_end_tests_linux',
         'end_to_end_tests_macos',

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A [GitHub CLI](https://cli.github.com/) [extension](https://cli.github.com/manua
 
 ## Supported migration paths
 
-* From GitHub Enterprise Server v3.10+ to:
-  * GitHub.com
-  * GitHub Enterprise Server v3.10+
-* From GitHub.com to:
-  * Another organization or user account on GitHub.com (e.g. from a classic GitHub.com organization to [Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) organization)
-  * GitHub Enterprise Server v3.10+
+- From GitHub Enterprise Server v3.11+ to:
+  - GitHub.com
+  - GitHub Enterprise Server v3.11+
+- From GitHub.com to:
+  - Another organization or user account on GitHub.com (e.g. from a classic GitHub.com organization to [Enterprise Managed Users](https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users) organization)
+  - GitHub Enterprise Server v3.11+
 
 ## Instructions
 
@@ -154,7 +154,8 @@ This tool only commits to supporting [GitHub Enterprise Server releases supporte
 
 If you want to export from or import to an old GitHub Enterprise Server version, you may need to use an earlier version of the tool:
 
-* For exports from GitHub Enterprise Server v3.7, v3.8 or v3.9, use version `v1.3.0` or earlier (`gh extension install timrogers/gh-migrate-project --pin v1.3.0`)
+- For exports from and imports to GitHub Enterprise Server v3.10, use version `v2.1.0` or earlier (`gh extension install timrogers/gh-migrate-project --pin v2.1.0
+- For exports from GitHub Enterprise Server v3.7, v3.8 or v3.9, use version `v1.3.0` or earlier (`gh extension install timrogers/gh-migrate-project --pin v1.3.0`)`)
 
 ### Draft issues will show the person running the migration as the author
 

--- a/src/github-products.ts
+++ b/src/github-products.ts
@@ -11,9 +11,9 @@ type GhesMetaResponse = DotcomMetaResponse & {
   };
 };
 
-export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION_FOR_EXPORTS = '3.10.0';
+export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION_FOR_EXPORTS = '3.11.0';
 
-export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION_FOR_IMPORTS = '3.10.0';
+export const MINIMUM_SUPPORTED_GITHUB_ENTERPRISE_SERVER_VERSION_FOR_IMPORTS = '3.11.0';
 
 export const getGitHubProductInformation = async (
   octokit: Octokit,


### PR DESCRIPTION
BREAKING CHANGE: This drops support for exports from GitHub Enterprise Server 3.10 as this version has now been [deprecated](https://docs.github.com/en/enterprise-server/admin/all-releases) by GitHub. v3.11 is now the earliest supported version for both exports and imports.