### PR TITLE
v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gh-migrate-project",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gh-migrate-project",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@fast-csv/parse": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-migrate-project",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "type": "module",
   "description": "A GitHub CLI (https://cli.github.com/) extension for migrating GitHub Projects (https://docs.github.com/en/issues/planning-and-tracking-with-projects) between GitHub accounts and products",
   "homepage": "https://github.com/timrogers/gh-migrate-project",


### PR DESCRIPTION
BREAKING CHANGE: This drops support for exports from GitHub Enterprise Server 3.10 as this version has now been [deprecated](https://docs.github.com/en/enterprise-server/admin/all-releases) by GitHub. v3.11 is now the earliest supported version for both exports and imports.