### PR TITLE
Update `seed-github-enterprise-server-instance` script to automatically configure Actions and Dependabot secrets for a new GHES instance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,13 +56,7 @@ From time to time, we need to add or remove supported GitHub Enterprise Server v
 
 1. Deploy a GitHub Enterprise Server (GHES) instance of the required version
 1. Create a personal access token (PAT) with the `repo`, `admin:org`, `site_admin` and `project` scopes
-1. Seed the GHES instance with data. You can do this by running `GITHUB_TOKEN=token GITHUB_BASE_URL=https://ghes.acme.com/api/v3 npm run seed-github-enterprise-server-instance`, replacing the environment variables as appropriate.
-1. Delete the personal access token (PAT) used for seeding, and create a new one with the `project`, `repo` and `admin:org` scopes.
-1. Create new [Actions secrets](https://github.com/timrogers/gh-migrate-project/settings/secrets/actions) and [Dependabot secrets](https://github.com/timrogers/gh-migrate-project/settings/secrets/dependabot) for the new GHES instance:
-
-- Set `GHES_XXX_BASE_URL` (e.g. `GHES_312_BASE_URL` for GHES 3.12) to your instance's API base URL, ending `/api/v3`
-- Set `GHES_XXX_ACCESS_TOKEN` to your access token
-
+1. Seed the GHES instance with data and configure the Actions and Dependabot secrets. You can do this by running `npm run seed-github-enterprise-server-instance -- --ghes-access-token TOKEN --ghes-base-url https://ghes.acme.com/api/v3 --dotcom-access-token FOO`.
 1. Open `.github/workflows/ci.yml` and make a copy of an existing job used to test a GHES version (e.g. `end_to_end_tests_linux_ghes_311`)
 1. Rename the job to an appropriate name for the new version, e.g. `end_to_end_tests_linux_ghes_312`
 1. Update the GHES version in the job's `name`
@@ -86,4 +80,4 @@ From time to time, you may need to update this token due to expiry or having rep
 To refresh the token and ensure an instance is ready:
 
 1. Create a new personal access token (PAT) with the `repo`, `admin:org`, `project` and `site_admin` scopes
-1. Update the `GHES_XXX_ACCESS_TOKEN` [Actions secret](https://github.com/timrogers/gh-migrate-project/settings/secrets/actions) and [Dependabot secret](https://github.com/timrogers/gh-migrate-project/settings/secrets/dependabot) appropriate to this GitHub Enterprise Server (GHES) instance (e.g. `GHES_312_BASE_URL` for GitHub Enterprise Server 3.12) with the new token.
+1. Update the Actions and Dependabot secrets by running `npm run seed-github-enterprise-server-instance -- --ghes-access-token TOKEN --ghes-base-url https://ghes.acme.com/api/v3 --dotcom-access-token FOO`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,9 @@
         "winston": "^3.15.0"
       },
       "devDependencies": {
+        "@types/libsodium-wrappers": "^0.7.14",
         "@types/node": "^22.7.5",
+        "@types/semver": "^7.5.8",
         "@typescript-eslint/eslint-plugin": "^8.8.1",
         "@typescript-eslint/parser": "^8.8.1",
         "@yao-pkg/pkg": "^5.15.0",
@@ -30,6 +32,7 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
+        "libsodium-wrappers": "^0.7.15",
         "prettier": "^3.3.3",
         "tsx": "^4.19.1",
         "typescript": "^5.6.2"
@@ -1033,6 +1036,12 @@
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.137.tgz",
       "integrity": "sha512-YNFwzVarXAOXkjuFxONyDw1vgRNzyH8AuyN19s0bM+ChSu/bzxb5XPxYFLXoqoM+tvgzwR3k7fXcEOW125yJxg=="
     },
+    "node_modules/@types/libsodium-wrappers": {
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.14.tgz",
+      "integrity": "sha512-5Kv68fXuXK0iDuUir1WPGw2R9fOZUlYlSAa0ztMcL0s0BfIDTqg9GXz8K30VJpPP3sxWhbolnQma2x+/TfkzDQ==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "22.7.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
@@ -1041,6 +1050,12 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -2873,6 +2888,21 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libsodium": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.15.tgz",
+      "integrity": "sha512-sZwRknt/tUpE2AwzHq3jEyUU5uvIZHtSssktXq7owd++3CSgn8RGrv6UZJJBpP7+iBghBqe7Z06/2M31rI2NKw==",
+      "dev": true
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.15.tgz",
+      "integrity": "sha512-E4anqJQwcfiC6+Yrl01C1m8p99wEhLmJSs0VQqST66SbQXXBoaJY0pF4BNjRYa/sOQAxx6lXAaAFIlx+15tXJQ==",
+      "dev": true,
+      "dependencies": {
+        "libsodium": "^0.7.15"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -28,14 +28,17 @@
     "winston": "^3.15.0"
   },
   "devDependencies": {
+    "@types/libsodium-wrappers": "^0.7.14",
+    "@types/node": "^22.7.5",
+    "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^8.8.1",
     "@typescript-eslint/parser": "^8.8.1",
-    "@types/node": "^22.7.5",
     "@yao-pkg/pkg": "^5.15.0",
     "esbuild": "^0.24.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "libsodium-wrappers": "^0.7.15",
     "prettier": "^3.3.3",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2"

--- a/script/seed-github-enterprise-server-instance.ts
+++ b/script/seed-github-enterprise-server-instance.ts
@@ -175,8 +175,8 @@ const createIssue = async ({
   return id;
 };
 
-const ORGANIZATION_LOGIN = 'gh-migrate-project-sandbox';
-const REPOSITORY_NAME = 'initial-repository';
+const INTEGRATION_TEST_ORGANIZATION_LOGIN = 'gh-migrate-project-sandbox';
+const INTEGRATION_TEST_REPOSITORY_NAME = 'initial-repository';
 
 (async () => {
   const logger = createLogger(false);
@@ -194,60 +194,60 @@ const REPOSITORY_NAME = 'initial-repository';
 
   logger.info('Seeding GHES instance...');
 
-  if (!(await isOrganizationAlreadyCreated({ login: ORGANIZATION_LOGIN, octokit }))) {
-    logger.info(`Creating organization ${ORGANIZATION_LOGIN}...`);
+  if (!(await isOrganizationAlreadyCreated({ login: INTEGRATION_TEST_ORGANIZATION_LOGIN, octokit }))) {
+    logger.info(`Creating organization ${INTEGRATION_TEST_ORGANIZATION_LOGIN}...`);
 
     const organizationId = await createOrganization({
-      login: ORGANIZATION_LOGIN,
+      login: INTEGRATION_TEST_ORGANIZATION_LOGIN,
       octokit,
     });
 
-    logger.info(`Created organization ${ORGANIZATION_LOGIN} with ID ${organizationId}`);
+    logger.info(`Created organization ${INTEGRATION_TEST_ORGANIZATION_LOGIN} with ID ${organizationId}`);
   }
 
   if (
     !(await isRepositoryAlreadyCreated({
-      organizationLogin: ORGANIZATION_LOGIN,
-      name: REPOSITORY_NAME,
+      organizationLogin: INTEGRATION_TEST_ORGANIZATION_LOGIN,
+      name: INTEGRATION_TEST_REPOSITORY_NAME,
       octokit,
     }))
   ) {
     logger.info(
-      `Creating repository ${REPOSITORY_NAME} in organization ${ORGANIZATION_LOGIN}...`,
+      `Creating repository ${INTEGRATION_TEST_REPOSITORY_NAME} in organization ${INTEGRATION_TEST_ORGANIZATION_LOGIN}...`,
     );
 
     const repositoryId = await createRepository({
-      organizationLogin: ORGANIZATION_LOGIN,
-      name: REPOSITORY_NAME,
+      organizationLogin: INTEGRATION_TEST_ORGANIZATION_LOGIN,
+      name: INTEGRATION_TEST_REPOSITORY_NAME,
       octokit,
     });
 
     logger.info(
-      `Created repository ${REPOSITORY_NAME} in organization ${ORGANIZATION_LOGIN} with ID ${repositoryId}`,
+      `Created repository ${INTEGRATION_TEST_REPOSITORY_NAME} in organization ${INTEGRATION_TEST_ORGANIZATION_LOGIN} with ID ${repositoryId}`,
     );
   }
 
   if (
     !(await isIssueAlreadyCreated({
-      organizationLogin: ORGANIZATION_LOGIN,
-      repositoryName: REPOSITORY_NAME,
+      organizationLogin: INTEGRATION_TEST_ORGANIZATION_LOGIN,
+      repositoryName: INTEGRATION_TEST_REPOSITORY_NAME,
       issueNumber: 1,
       octokit,
     }))
   ) {
     logger.info(
-      `Creating issue #1 in repository ${REPOSITORY_NAME} in organization ${ORGANIZATION_LOGIN}...`,
+      `Creating issue #1 in repository ${INTEGRATION_TEST_REPOSITORY_NAME} in organization ${INTEGRATION_TEST_ORGANIZATION_LOGIN}...`,
     );
 
     const issueId = await createIssue({
-      organizationLogin: ORGANIZATION_LOGIN,
-      repositoryName: REPOSITORY_NAME,
+      organizationLogin: INTEGRATION_TEST_ORGANIZATION_LOGIN,
+      repositoryName: INTEGRATION_TEST_REPOSITORY_NAME,
       title: 'A crucial issue',
       octokit,
     });
 
-    console.log(
-      `Created issue #1 in repository ${REPOSITORY_NAME} in organization ${ORGANIZATION_LOGIN} with ID ${issueId}`,
+    logger.info(
+      `Created issue #1 in repository ${INTEGRATION_TEST_REPOSITORY_NAME} in organization ${INTEGRATION_TEST_ORGANIZATION_LOGIN} with ID ${issueId}`,
     );
   }
 

--- a/script/seed-github-enterprise-server-instance.ts
+++ b/script/seed-github-enterprise-server-instance.ts
@@ -1,5 +1,5 @@
 import { type Octokit as OctokitType } from 'octokit';
-import { Octokit } from 'octokit';
+import { createOctokit } from '../src/octokit';
 import { createLogger } from '../src/logger';
 import { GraphqlResponseError } from '@octokit/graphql';
 
@@ -175,16 +175,24 @@ const createIssue = async ({
   return id;
 };
 
-const octokit = new Octokit({
-  auth: process.env.GITHUB_TOKEN,
-  baseUrl: process.env.GITHUB_BASE_URL,
-});
-
 const ORGANIZATION_LOGIN = 'gh-migrate-project-sandbox';
 const REPOSITORY_NAME = 'initial-repository';
 
 (async () => {
   const logger = createLogger(false);
+
+  if (!process.env.GITHUB_BASE_URL) {
+    throw new Error('GITHUB_BASE_URL is not set');
+  }
+
+  const octokit = createOctokit(
+    process.env.GITHUB_TOKEN,
+    process.env.GITHUB_BASE_URL,
+    undefined,
+    logger,
+  );
+
+  logger.info('Seeding GHES instance...');
 
   if (!(await isOrganizationAlreadyCreated({ login: ORGANIZATION_LOGIN, octokit }))) {
     logger.info(`Creating organization ${ORGANIZATION_LOGIN}...`);

--- a/script/seed-github-enterprise-server-instance.ts
+++ b/script/seed-github-enterprise-server-instance.ts
@@ -309,13 +309,19 @@ const opts = program.opts() as {
   const githubProductInformation = await getGitHubProductInformation(octokit);
 
   if (githubProductInformation.githubProduct !== GitHubProduct.GHES) {
-    throw new Error(`Expected ${opts.ghesBaseUrl} to be a GitHub Enterprise Server instance`);
+    throw new Error(
+      `Expected ${opts.ghesBaseUrl} to be a GitHub Enterprise Server instance`,
+    );
   }
 
-  const parsedGhesVersion = semver.parse(githubProductInformation.gitHubEnterpriseServerVersion);
+  const parsedGhesVersion = semver.parse(
+    githubProductInformation.gitHubEnterpriseServerVersion,
+  );
 
   if (!parsedGhesVersion) {
-    throw new Error(`Failed to parse GitHub Enterprise Server version: ${githubProductInformation.gitHubEnterpriseServerVersion}`);
+    throw new Error(
+      `Failed to parse GitHub Enterprise Server version: ${githubProductInformation.gitHubEnterpriseServerVersion}`,
+    );
   }
 
   logger.info('Seeding GHES instance...');

--- a/script/seed-github-enterprise-server-instance.ts
+++ b/script/seed-github-enterprise-server-instance.ts
@@ -1,5 +1,6 @@
 import { type Octokit as OctokitType } from 'octokit';
 import { Octokit } from 'octokit';
+import { createLogger } from '../src/logger';
 import { GraphqlResponseError } from '@octokit/graphql';
 
 const createOrganization = async ({
@@ -183,15 +184,17 @@ const ORGANIZATION_LOGIN = 'gh-migrate-project-sandbox';
 const REPOSITORY_NAME = 'initial-repository';
 
 (async () => {
+  const logger = createLogger(false);
+
   if (!(await isOrganizationAlreadyCreated({ login: ORGANIZATION_LOGIN, octokit }))) {
-    console.log(`Creating organization ${ORGANIZATION_LOGIN}...`);
+    logger.info(`Creating organization ${ORGANIZATION_LOGIN}...`);
 
     const organizationId = await createOrganization({
       login: ORGANIZATION_LOGIN,
       octokit,
     });
 
-    console.log(`Created organization ${ORGANIZATION_LOGIN} with ID ${organizationId}`);
+    logger.info(`Created organization ${ORGANIZATION_LOGIN} with ID ${organizationId}`);
   }
 
   if (
@@ -201,7 +204,7 @@ const REPOSITORY_NAME = 'initial-repository';
       octokit,
     }))
   ) {
-    console.log(
+    logger.info(
       `Creating repository ${REPOSITORY_NAME} in organization ${ORGANIZATION_LOGIN}...`,
     );
 
@@ -211,7 +214,7 @@ const REPOSITORY_NAME = 'initial-repository';
       octokit,
     });
 
-    console.log(
+    logger.info(
       `Created repository ${REPOSITORY_NAME} in organization ${ORGANIZATION_LOGIN} with ID ${repositoryId}`,
     );
   }
@@ -224,7 +227,7 @@ const REPOSITORY_NAME = 'initial-repository';
       octokit,
     }))
   ) {
-    console.log(
+    logger.info(
       `Creating issue #1 in repository ${REPOSITORY_NAME} in organization ${ORGANIZATION_LOGIN}...`,
     );
 


### PR DESCRIPTION
The `seed-github-enterprise-server-instance` script is used to configure a new GitHub Enterprise Server (GHES) instance for integration tests. 

This updates the script so that it also configures the required Actions and Dependabot secrets in CI/CD, rather than having to do this as a manual step.