### PR TITLE
When using a token with OAuth scopes, validate that the required scopes are enabled

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -10,6 +10,7 @@ import {
   checkForUpdates,
   logRateLimitInformation,
   normalizeBaseUrl,
+  validateTokenOAuthScopes,
 } from '../utils.js';
 import VERSION from '../version.js';
 import { createLogger, Logger } from '../logger.js';
@@ -533,6 +534,12 @@ command
           },
         });
       }
+
+      await validateTokenOAuthScopes({
+        octokit,
+        logger,
+        requiredScopes: new Set(['repo', new Set(['project', 'read:project'])]),
+      });
 
       logger.info(
         `Looking up ID for project ${projectNumber} owned by ${projectOwnerType} ${projectOwner}...`,

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -13,6 +13,7 @@ import {
   checkForUpdates,
   logRateLimitInformation,
   normalizeBaseUrl,
+  validateTokenOAuthScopes,
 } from '../utils.js';
 import VERSION from '../version.js';
 import { Logger, createLogger } from '../logger.js';
@@ -987,6 +988,16 @@ command
           },
         });
       }
+
+      const requiredScopes: Set<string | Set<string>> = new Set(['repo', 'project']);
+
+      // When creating an organization-owned project, either the write:org or admin:org
+      // scope must be available
+      if (projectOwnerType === ProjectOwnerType.Organization) {
+        requiredScopes.add(new Set(['write:org', 'admin:org']));
+      }
+
+      await validateTokenOAuthScopes({ octokit, requiredScopes, logger });
 
       logger.info(`Looking up ID for target ${projectOwnerType} ${projectOwner}...`);
       const ownerId = await getOwnerGlobalId({ octokit, projectOwner, projectOwnerType });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,9 +2,8 @@ import winston from 'winston';
 const { combine, timestamp, printf, colorize } = winston.format;
 
 // TODO: Figure out how to make ESLint happy with this
-// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+
 const format = printf(({ level, message, timestamp }): string => {
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   return `${timestamp} ${level}: ${message}`;
 });
 


### PR DESCRIPTION
This adds a new step to the `export` and `import` commands to validate that the provided token has the required OAuth scopes. 

This only works for tokens which use OAuth scopes, and not those which use fine-grained permissions (e.g. PATs v2), in which case, it'll be a no-op.

If required scopes are missing, we exit early with a clear error message.