### PR TITLE
feat: Status Field Migration for GitHub Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ Optionally, you can specify an existing project using `--project-number` to appl
 
 ## Limitations
 
+### Automatic `Status` field migration to GitHub Enterprise Server
+
+Due to limitations of the GitHub Enterprise Server GraphQL API, automatic migration of `Status` field is not supported for imports against GitHub Enterprise Server.
+
+Due to this limitation, the tool will ask you to manually set up your options for the "Status" field before starting the import if the target is GitHub Enterprise Server. It will explain exactly what to do, and will validate that you've correctly copied the options from your migration source.
+
+Once you've set up the "Status" field, your project will be imported.
+
 ### Classic projects are not supported
 
 This tool can't migrate so-called classic Projects - only the newer version of [GitHub Projects](https://docs.github.com/en/issues/planning-and-tracking-with-projects).

--- a/README.md
+++ b/README.md
@@ -161,9 +161,7 @@ gh migrate-project import \
     --project-number 1337
 ```
 
-Near the start of the import, the tool will ask you to manually set up your options for the "Status" field. It will explain exactly what to do, and will validate that you've correctly copied the options from your migration source.
-
-Once you've set up the "Status" field, your project will be imported. Watch out for `warn` lines in the logs, which will let you know about data which hasn't been imported.
+Watch out for `warn` lines in the logs, which will let you know about data which hasn't been imported.
 
 Optionally, you can specify an existing project using `--project-number` to apply the fields and items to a project you've already created. This can be useful if you want to use a [project template](https://docs.github.com/en/issues/planning-and-tracking-with-projects/managing-your-project/managing-project-templates-in-your-organization) to set up your projects to overcome this tool's lack of support for migrating workflows and views.
 

--- a/README.md
+++ b/README.md
@@ -167,11 +167,11 @@ Optionally, you can specify an existing project using `--project-number` to appl
 
 ## Limitations
 
-### Automatic `Status` field migration to GitHub Enterprise Server
+### Migrating a `Status` field with custom options to GitHub Enterprise Server requires manual steps
 
-Due to limitations of the GitHub Enterprise Server GraphQL API, automatic migration of `Status` field is not supported for imports against GitHub Enterprise Server.
+Due to limitations of the GitHub Enterprise Server GraphQL API, automatic migration of the `Status` field is not supported for imports to GitHub Enterprise Server if the `Status` field has custom options configured.
 
-Due to this limitation, the tool will ask you to manually set up your options for the "Status" field before starting the import if the target is GitHub Enterprise Server. It will explain exactly what to do, and will validate that you've correctly copied the options from your migration source.
+Due to this limitation, the tool will ask you to manually set up your options for the "Status" field mid-way through the import if the target is GitHub Enterprise Server. It will explain exactly what to do, and will validate that you've correctly copied the options from your migration source.
 
 Once you've set up the "Status" field, your project will be imported.
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -201,7 +201,7 @@ const isFieldDescriptionAndColorAvailable = (gitHubEnterpriseServerVersion: stri
     let majorVersion = parseInt(version[0]);
     let minorVersion = parseInt(version[1]);
     // At the time of writing, these fields are present on GitHub.com and Enterprise Server Version >= 3.11
-    return majorVersion >= 3 && minorVersion >= 11
+    return (majorVersion > 3) || (majorVersion == 3 && minorVersion >= 11)
   }
 
   // GitHub.com

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -195,19 +195,6 @@ const getProjectItems = async ({
   return validProjectItems;
 };
 
-const isFieldDescriptionAndColorAvailable = (gitHubEnterpriseServerVersion: string | undefined): boolean => {
-  if (gitHubEnterpriseServerVersion) {
-    const version = gitHubEnterpriseServerVersion.split('.')
-    let majorVersion = parseInt(version[0]);
-    let minorVersion = parseInt(version[1]);
-    // At the time of writing, these fields are present on GitHub.com and Enterprise Server Version >= 3.11
-    return (majorVersion > 3) || (majorVersion == 3 && minorVersion >= 11)
-  }
-
-  // GitHub.com
-  return typeof gitHubEnterpriseServerVersion === 'undefined'
-}
-
 const getProject = async ({
   id,
   octokit,
@@ -217,8 +204,6 @@ const getProject = async ({
   octokit: Octokit;
   gitHubEnterpriseServerVersion: string | undefined;
 }): Promise<Project> => {
-
-  const shouldGetFieldDescriptionAndColor = isFieldDescriptionAndColorAvailable(gitHubEnterpriseServerVersion)
 
   const response = (await octokit.graphql(
     `query getProject($id: ID!) {
@@ -253,8 +238,8 @@ const getProject = async ({
                 options {
                   id
                   name
-                  ${shouldGetFieldDescriptionAndColor ? 'description' : ''}
-                  ${shouldGetFieldDescriptionAndColor ? 'color' : ''}
+                  description
+                  color
                 }
               }
             }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -118,7 +118,7 @@ const getProjectItems = async ({
                         name
                       }
                     }
-                  } 
+                  }
                   ... on ProjectV2ItemFieldNumberValue {
                     number
                     field {
@@ -195,6 +195,19 @@ const getProjectItems = async ({
   return validProjectItems;
 };
 
+const isFieldDescriptionAndColorAvailable = (gitHubEnterpriseServerVersion: string | undefined): boolean => {
+  if (gitHubEnterpriseServerVersion) {
+    const version = gitHubEnterpriseServerVersion.split('.')
+    let majorVersion = parseInt(version[0]);
+    let minorVersion = parseInt(version[1]);
+    // At the time of writing, these fields are present on GitHub.com and Enterprise Server Version >= 3.11
+    return majorVersion >= 3 && minorVersion >= 11
+  }
+
+  // GitHub.com
+  return typeof gitHubEnterpriseServerVersion === 'undefined'
+}
+
 const getProject = async ({
   id,
   octokit,
@@ -204,9 +217,8 @@ const getProject = async ({
   octokit: Octokit;
   gitHubEnterpriseServerVersion: string | undefined;
 }): Promise<Project> => {
-  // At the time of writing, these fields are only present on GitHub.com
-  const shouldGetFieldDescriptionAndColor =
-    typeof gitHubEnterpriseServerVersion === 'undefined';
+
+  const shouldGetFieldDescriptionAndColor = isFieldDescriptionAndColorAvailable(gitHubEnterpriseServerVersion)
 
   const response = (await octokit.graphql(
     `query getProject($id: ID!) {
@@ -305,8 +317,8 @@ const getProject = async ({
               }
             }
             totalCount
-          } 
-        } 
+          }
+        }
       }
     }`,
     {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1296,7 +1296,7 @@ command
 
       // At the time of writing this, the GraphQL mutation 'updateProjectV2Field' is only available on
       // GitHub.com
-      const shouldConfigureStatusField = typeof gitHubEnterpriseServerVersion === 'undefined'
+      const shouldConfigureStatusField = githubProduct !== GitHubProduct.GHES
       if (shouldConfigureStatusField) {
         const sourceProjectStatusField = sourceProject.fields.nodes.find(field => field.name == "Status")!;
         const sourceProjectStatusFieldOptions = sourceProjectStatusField.options!;

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1317,7 +1317,7 @@ command
         )
 
         const mappings = correlateCustomFieldOptions(
-          sourceProjectStatusField.options as Array<{ id: string; name: string }>,
+          sourceProjectStatusField.options!,
           targetProjectStatusFieldOptions,
         );
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -490,7 +490,7 @@ const getProjectStatusField = async ({
   return response.node.field;
 };
 
-const updateProjectStatusField = async ({ octokit, statusFieldId, options }: { octokit: Octokit; statusFieldId: string; options: SelectOption[] }): Promise<Array<{ id: string; name: string }>> => {
+const updateProjectStatusField = async ({ octokit, statusFieldId, options }: { octokit: Octokit; statusFieldId: string; options: SelectOption[] }): Promise<{ id: string; name: string }[]> => {
   const response = (await octokit.graphql(
     `mutation updateProjectStatusField($id: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
       updateProjectV2Field(input: { fieldId: $id, name: "Status", singleSelectOptions: $options }) {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -216,8 +216,8 @@ const createProject = async ({
 
 interface SelectOption {
   name: string;
-  color: ProjectSingleSelectFieldOptionColor;
-  description: string;
+  color?: ProjectSingleSelectFieldOptionColor;
+  description?: string;
 }
 
 interface CreatedProjectField {
@@ -490,7 +490,7 @@ const getProjectStatusField = async ({
   return response.node.field;
 };
 
-const updateProjectStatusField = async ({octokit, statusFieldId, options}: {octokit: Octokit; statusFieldId: string; options: SelectOption[]}): Promise<Array<{id: string; name: string}>> => {
+const updateProjectStatusField = async ({ octokit, statusFieldId, options }: { octokit: Octokit; statusFieldId: string; options: SelectOption[] }): Promise<Array<{ id: string; name: string }>> => {
   const response = (await octokit.graphql(
     `mutation updateProjectStatusField($id: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
       updateProjectV2Field(input: { fieldId: $id, name: "Status", singleSelectOptions: $options }) {
@@ -506,10 +506,10 @@ const updateProjectStatusField = async ({octokit, statusFieldId, options}: {octo
         }
       }
     }`,
-  {
-    id: statusFieldId,
-    options: options,
-  }) as {updateProjectV2Field: {projectV2Field: { id: string; name: string; options: Array<{id: string; name: string}>}}})
+    {
+      id: statusFieldId,
+      options: options,
+    }) as { updateProjectV2Field: { projectV2Field: { id: string; name: string; options: Array<{ id: string; name: string }> } } })
 
   return response.updateProjectV2Field.projectV2Field.options;
 }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1301,7 +1301,7 @@ command
         const sourceProjectStatusField = sourceProject.fields.nodes.find(field => field.name === "Status")!;
         const sourceProjectStatusFieldOptions = sourceProjectStatusField.options!;
 
-        logger.info(`Configuring "Status" field: ${JSON.stringify(sourceProjectStatusFieldOptions)}`);
+        logger.info('Configuring "Status" field options...');
 
         const targetProjectStatusField = await getProjectStatusField({
           octokit,

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1295,7 +1295,7 @@ command
       logger.info(`Created ${customFieldsToCreate.length} custom field(s)`);
 
       // At the time of writing this, the GraphQL mutation 'updateProjectV2Field' is only available on
-      // GitHub.com
+      // GitHub.com and GitHub Enterprise Cloud with Data Residency
       const shouldConfigureStatusField = githubProduct !== GitHubProduct.GHES
       if (shouldConfigureStatusField) {
         const sourceProjectStatusField = sourceProject.fields.nodes.find(field => field.name == "Status")!;

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1312,11 +1312,7 @@ command
           {
             octokit,
             statusFieldId: targetProjectStatusField.id,
-            options: sourceProjectStatusFieldOptions.map(option => ({
-              name: option.name,
-              color: option.color,
-              description: option.description,
-            } as SelectOption))
+            options: sourceProjectStatusFieldOptions
           }
         )
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1298,7 +1298,7 @@ command
       // GitHub.com and GitHub Enterprise Cloud with Data Residency
       const shouldConfigureStatusField = githubProduct !== GitHubProduct.GHES
       if (shouldConfigureStatusField) {
-        const sourceProjectStatusField = sourceProject.fields.nodes.find(field => field.name == "Status")!;
+        const sourceProjectStatusField = sourceProject.fields.nodes.find(field => field.name === "Status")!;
         const sourceProjectStatusFieldOptions = sourceProjectStatusField.options!;
 
         logger.info(`Configuring "Status" field: ${JSON.stringify(sourceProjectStatusFieldOptions)}`);

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -508,7 +508,12 @@ const updateProjectStatusField = async ({ octokit, statusFieldId, options }: { o
     }`,
     {
       id: statusFieldId,
-      options: options,
+      // This casting is required, as `id` field does not exist on type `ProjectV2SingleSelectFieldOptionInput`
+      options: options.map(option => ({
+        name: option.name,
+        color: option.color,
+        description: option.description,
+      } as SelectOption)),
     }) as { updateProjectV2Field: { projectV2Field: { id: string; name: string; options: Array<{ id: string; name: string }> } } })
 
   return response.updateProjectV2Field.projectV2Field.options;


### PR DESCRIPTION
GitHub recently [added](https://docs.github.com/en/graphql/overview/changelog#schema-changes-for-2024-12-04-1) `updateProjectV2Field` mutation to the GraphQL API. This PR adds the ability to migrate `Status` field automatically using this new mutation if the target instance is GitHub.com.

Changes:

- Refactored the logic of determining the existence of `color` and `description` fields of the type `ProjectV2SingleSelectFieldOption` when running `export` command
- Add support for exporting `color` and `description` fields for `export` jobs against GitHub Enterprise Server >= 3.11
- Add support for automatic "Status" field migration for `import` jobs against GitHub.com.