### PR TITLE
feat: support running imports targeting an already-created project

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ If you don't want to map a user, just delete the line from the CSV or leave the 
 
 You've exported your data and filled out the repository mappings template. You can now import your project into your migration target.
 
-To export a project, you'll need a token with appropriate permissions. The extension won't use your existing login session for the GitHub CLI. You'll need a classic token with the `project` and `repo` scopes, [authorized for SSO](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on) if applicable. If you're creating an organization project, you'll also need the `write:org` scope.
+To import a project, you'll need a token with appropriate permissions. The extension won't use your existing login session for the GitHub CLI. You'll need a classic token with the `project` and `repo` scopes, [authorized for SSO](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on) if applicable. If you're creating an organization project, you'll also need the `write:org` scope.
 
 You can import your project using the `gh migrate-project import` command:
 
@@ -156,12 +156,16 @@ gh migrate-project import \
     # OPTIONAL: Skip verification of SSL certificates when connecting to GitHub. You may need to use this option if connecting to a GitHub Enterprise Server instance with a self-signed certificate, or if you have configured a proxy.
     --skip-certificate-verification \
     # OPTIONAL: Skip automatic check for updates to this tool
-    --skip-update-check
+    --skip-update-check \
+    # OPTIONAL: The number of an existing project you have already created to use as a migration target, importing the items and fields. If this is set, the project title in the export or specified with --project-title will not be applied.
+    --project-number 1337
 ```
 
 Near the start of the import, the tool will ask you to manually set up your options for the "Status" field. It will explain exactly what to do, and will validate that you've correctly copied the options from your migration source.
 
 Once you've set up the "Status" field, your project will be imported. Watch out for `warn` lines in the logs, which will let you know about data which hasn't been imported.
+
+Optionally, you can specify an existing project using `--project-number` to apply the fields and items to a project you've already created. This can be useful if you want to use a [project template](https://docs.github.com/en/issues/planning-and-tracking-with-projects/managing-your-project/managing-project-templates-in-your-organization) to set up your projects to overcome this tool's lack of support for migrating workflows and views.
 
 ## Limitations
 
@@ -179,6 +183,8 @@ The following data is not migrated and will be skipped:
 - The order of project items displayed in your views
 - Workflows
 - Iteration custom fields
+
+You may want to add views and workflows to a template, manually create your project from a template, and then use the `import` command's `--project-number` option to import items and fields into that project.
 
 ### Supported GitHub Enterprise Server versions
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1219,6 +1219,9 @@ command
 
       for (const customFieldToCreate of customFieldsToCreate) {
         const { id, dataType, name, options } = customFieldToCreate;
+
+        logger.info(`Creating '${name}' field...`);
+
         const fieldOptionsForCreation = options
           ? options.map((option) => {
               const newOption = {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -55,6 +55,7 @@ interface Arguments {
   projectOwner: string;
   projectOwnerType: ProjectOwnerType;
   projectTitle?: string;
+  projectNumber?: number;
   proxyUrl: string | undefined;
   repositoryMappingsPath: string;
   skipCertificateVerification: boolean;
@@ -970,7 +971,7 @@ command
   )
   .option('--skip-update-check', 'Skip automatic check for updates to this tool', false)
   .option(
-    '--project-number',
+    '--project-number <project_number>',
     'The number of an existing project you have already created to use as a migration target, importing the items and fields. If this is set, the project title in the export or specified with --project-title will not be applied.',
     (value) => parseInt(value),
   )
@@ -1133,8 +1134,8 @@ command
 
       const title = projectTitle || sourceProject.title;
 
-      let targetProjectId: string = null;
-      let targetProjectUrl: string = null;
+      let targetProjectId: string | null = null;
+      let targetProjectUrl: string | null = null;
 
       if (projectNumber) {
         const result = await getGlobalIdAndUrlForProject({

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -1,0 +1,90 @@
+import { Octokit } from 'octokit';
+
+export enum ProjectOwnerType {
+  Organization = 'organization',
+  User = 'user',
+}
+
+export const getGlobalIdAndUrlForProject = async ({
+  owner,
+  ownerType,
+  number,
+  octokit,
+}: {
+  owner: string;
+  ownerType: ProjectOwnerType;
+  number: number;
+  octokit: Octokit;
+}): Promise<{ globalId: string; url: string }> => {
+  switch (ownerType) {
+    case ProjectOwnerType.Organization:
+      return await getGlobalIdAndUrlForOrganizationOwnedProject({
+        organization: owner,
+        number,
+        octokit,
+      });
+    case ProjectOwnerType.User:
+      return await getGlobalIdForUserOwnedProject({
+        user: owner,
+        number,
+        octokit,
+      });
+  }
+};
+
+const getGlobalIdAndUrlForOrganizationOwnedProject = async ({
+  organization,
+  number,
+  octokit,
+}: {
+  organization: string;
+  number: number;
+  octokit: Octokit;
+}): Promise<{ globalId: string; url: string }> => {
+  const response = (await octokit.graphql(
+    `query getProjectGlobalId($organization: String!, $number: Int!) {
+      organization(login: $organization) {
+        projectV2(number: $number) {
+          id
+          url
+        }
+      }
+    }`,
+    {
+      organization,
+      number,
+    },
+  )) as { organization: { projectV2: { id: string; url: string } } };
+
+  return {
+    globalId: response.organization.projectV2.id,
+    url: response.organization.projectV2.url,
+  };
+};
+
+const getGlobalIdForUserOwnedProject = async ({
+  user,
+  number,
+  octokit,
+}: {
+  user: string;
+  number: number;
+  octokit: Octokit;
+}): Promise<{ globalId: string; url: string }> => {
+  const response = (await octokit.graphql(
+    `query getProjectGlobalId($user: String!, $number: Int!) {
+      user(login: $user) {
+        projectV2(number: $number) {
+          id
+          url
+        }
+      }
+    }`,
+    {
+      user,
+      number,
+    },
+  )) as { user: { projectV2: { id: string; url: string } } };
+
+  return { globalId: response.user.projectV2.id, url: response.user.projectV2.url };
+};


### PR DESCRIPTION
As proposed by @cameronraysmith in #395, this adds the ability for the `import` command to target an existing project that has already been created. The import process will take that project, setup the fields and add the items.

This can be useful for circumventing the GitHub API's lack of support for managing project workflows and views, which means that this tool can't support migrating that data. Instead, you can set up those things in a project template, create a project from that template, and then run the import.

Closes #395.