### PR TITLE
Add support to authenticate using GitHub App installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,54 @@ Watch out for `warn` lines in the logs, which will let you know about data which
 
 Optionally, you can specify an existing project using `--project-number` to apply the fields and items to a project you've already created. This can be useful if you want to use a [project template](https://docs.github.com/en/issues/planning-and-tracking-with-projects/managing-your-project/managing-project-templates-in-your-organization) to set up your projects to overcome this tool's lack of support for migrating workflows and views.
 
+### Authentication
+
+For the commands [export](#step-3-export-your-project-from-migration-source) and [import](#step-6-import-your-project-into-your-migration-target), this tool supports two types of authentication: `token` which expects a Personal Access Token or `installation` which uses a GitHub App installation for authentication. The tool will automatically determine the authentication type based on the provided parameters.
+
+- If a `--access-token` or `GITHUB_TOKEN` is provided it is assumed that the [token](#token-authentication) approach should be taken.
+- If a `--app-installation-id` or `GITHUB_APP_INSTALLATION_ID` is provided it is assumed that the [installation](#installation-authentication) approach should be taken. This approach also requires that an `--app-id` and also `--private-key` be provided in addition to the `--app-installation-id`.
+
+#### Token Authentication
+
+By default, the extension expects an access token with appropriate scopes to be provided with the `--access-token` argument or `GITHUB_ACCESS_TOKEN` environment variable.
+
+```bash
+gh migrate-project export \
+    # A GitHub access token with the permissions described above. This can also be configured using the `GITHUB_TOKEN` environment variable.
+    --access-token GITHUB_TOKEN \
+    # The login of the user or organization that owns the project
+    --project-owner monalisa \
+    # The type of the owner of the project you want to export (defaults to organization; only required if the owner is a user)
+    --project-owner-type user \
+    # The number of the project you want to export
+    --project-number 1337
+```
+
+#### Installation Authentication
+
+Instead of [token authentication](#token-authentication), installation authentication can be used by providing values for `--app-id`, `--app-installation-id`, and either `--private-key` or `--private-key-file`. Use of environment variables is also supported by providing `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and either `GITHUB_APP_PRIVATE_KEY` or `GITHUB_APP_PRIVATE_KEY_FILE`.
+
+Installation Authentication uses a `GitHub App` to access resources on behalf of a user in an organization and can provide longer-lived integration. A [personal access token](#token-authentication) is great for short-lived scripts but if you have a large organization you are trying to audit you should consider using a GitHub App instead. Additionally, a personal access token is associated with a user and can cause the process to fail if the user no longer has access to the resources you are migrating. A GitHub App is not dependent on a user.
+
+```bash
+gh migrate-project export \
+    # The GitHub app ID
+    --app-id GITHUB_APP_ID \
+    # The private key of the GitHub App. Alternatively, use --private-key-file if you have a .pem file.
+    --private-key GITHUB_APP_PRIVATE_KEY \
+    # OR
+    # The private key of the GitHub App. For example, path to a *.pem file you downloaded from the about page of the GitHub App.
+    --private-key-file /path/to/private-key-file.pem \
+    # The GitHub app installation ID
+    --app-installation-id GITHUB_APP_INSTALLATION_ID \
+    # The login of the user or organization that owns the project
+    --project-owner monalisa \
+    # The type of the owner of the project you want to export (defaults to organization; only required if the owner is a user)
+    --project-owner-type user \
+    # The number of the project you want to export
+    --project-number 1337
+```
+
 ## Limitations
 
 ### Migrating a `Status` field with custom options to GitHub Enterprise Server requires manual steps

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ gh migrate-project export \
 
 Instead of [token authentication](#token-authentication), installation authentication can be used by providing values for `--app-id`, `--app-installation-id`, and either `--private-key` or `--private-key-file`. Use of environment variables is also supported by providing `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and either `GITHUB_APP_PRIVATE_KEY` or `GITHUB_APP_PRIVATE_KEY_FILE`.
 
-Installation Authentication uses a `GitHub App` to access resources on behalf of a user in an organization and can provide longer-lived integration. A [personal access token](#token-authentication) is great for short-lived scripts but if you have a large organization you are trying to audit you should consider using a GitHub App instead. Additionally, a personal access token is associated with a user and can cause the process to fail if the user no longer has access to the resources you are migrating. A GitHub App is not dependent on a user.
+Installation Authentication uses a `GitHub App` to access resources on behalf of a user in an organization and can provide longer-lived integration. A [personal access token](#token-authentication) is great for short-lived scripts but if you have a large project you are trying to migrate you should consider using a GitHub App instead. Additionally, a personal access token is associated with a user and can cause the process to fail if the user no longer has access to the resources you are migrating. A GitHub App is not dependent on a user.
 
 ```bash
 gh migrate-project export \

--- a/package-lock.json
+++ b/package-lock.json
@@ -4232,10 +4232,11 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",

--- a/script/configure-github-enterprise-server-instance.ts
+++ b/script/configure-github-enterprise-server-instance.ts
@@ -317,7 +317,12 @@ const opts = program.opts() as {
     process.exit(1);
   }
 
-  const octokit = createOctokit(ghesAccessToken, opts.ghesBaseUrl, undefined, logger);
+  const octokit = createOctokit(
+    { auth: ghesAccessToken },
+    opts.ghesBaseUrl,
+    undefined,
+    logger,
+  );
 
   const githubProductInformation = await getGitHubProductInformation(octokit);
 
@@ -409,7 +414,7 @@ const opts = program.opts() as {
   const ghesVersionForSecretName = `${parsedGhesVersion.major}${parsedGhesVersion.minor}`;
 
   const dotcomOctokit = createOctokit(
-    dotcomAccessToken,
+    { auth: dotcomAccessToken },
     'https://api.github.com',
     undefined,
     logger,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,113 @@
+import { createAppAuth, StrategyOptions } from '@octokit/auth-app';
+import { AuthInterface } from '@octokit/auth-app/dist-types/types';
+import { Logger } from './logger';
+import { readFileSync } from 'fs';
+
+export interface AuthConfig {
+  authStrategy?: ((options: StrategyOptions) => AuthInterface) | undefined;
+  auth:
+    | string
+    | { appId: number; privateKey: string; installationId: number }
+    | undefined;
+}
+
+const getAuthAppId = (appId?: string): number => {
+  const authAppId = appId || process.env.GITHUB_APP_ID;
+  if (!authAppId || isNaN(parseInt(authAppId))) {
+    throw new Error(
+      'You must specify a GitHub app ID using the --app-id argument or GITHUB_APP_ID environment variable.',
+    );
+  }
+  return parseInt(authAppId);
+};
+
+const getAuthPrivateKey = (privateKey?: string, privateKeyFile?: string): string => {
+  let authPrivateKey: string | undefined;
+
+  if (privateKeyFile || process.env.GITHUB_APP_PRIVATE_KEY_FILE) {
+    const filePath = privateKeyFile || process.env.GITHUB_APP_PRIVATE_KEY_FILE;
+    authPrivateKey = filePath ? readFileSync(filePath, 'utf-8') : undefined;
+  } else if (privateKey || process.env.GITHUB_APP_PRIVATE_KEY) {
+    authPrivateKey = privateKey || process.env.GITHUB_APP_PRIVATE_KEY;
+  }
+
+  if (!authPrivateKey) {
+    throw new Error(
+      'You must specify a GitHub app private key using the --private-key argument, --private-key-file argument, GITHUB_APP_PRIVATE_KEY_FILE environment variable, or GITHUB_APP_PRIVATE_KEY environment variable.',
+    );
+  }
+
+  return authPrivateKey;
+};
+
+const getAuthInstallationId = (appInstallationId?: string): number => {
+  const authInstallationId = appInstallationId || process.env.GITHUB_APP_INSTALLATION_ID;
+  if (!authInstallationId || isNaN(parseInt(authInstallationId))) {
+    throw new Error(
+      'You must specify a GitHub app installation ID using the --app-installation-id argument or GITHUB_APP_INSTALLATION_ID environment variable.',
+    );
+  }
+  return parseInt(authInstallationId);
+};
+
+const getTokenAuthConfig = (accessToken?: string): AuthConfig => {
+  const authToken = accessToken || process.env.GITHUB_TOKEN;
+  if (!authToken) {
+    throw new Error(
+      'You must specify a GitHub access token using the --access-token argument or GITHUB_TOKEN environment variable.',
+    );
+  }
+  return { authStrategy: undefined, auth: authToken };
+};
+
+const getInstallationAuthConfig = (
+  appId?: string,
+  privateKey?: string,
+  privateKeyFile?: string,
+  appInstallationId?: string,
+): AuthConfig => {
+  const auth = {
+    appId: getAuthAppId(appId),
+    privateKey: getAuthPrivateKey(privateKey, privateKeyFile),
+    installationId: getAuthInstallationId(appInstallationId),
+  };
+  return { authStrategy: createAppAuth, auth };
+};
+
+export const createAuthConfig = ({
+  accessToken,
+  appId,
+  privateKey,
+  privateKeyFile,
+  appInstallationId,
+  logger,
+}: {
+  accessToken?: string | undefined;
+  appId?: string | undefined;
+  privateKey?: string | undefined;
+  privateKeyFile?: string | undefined;
+  appInstallationId?: string | undefined;
+  logger: Logger;
+}): AuthConfig => {
+  try {
+    if (appInstallationId || process.env.GITHUB_APP_INSTALLATION_ID) {
+      logger.info(
+        'GitHub App installation ID detected. Authenticating using GitHub App installation...',
+      );
+      return getInstallationAuthConfig(
+        appId,
+        privateKey,
+        privateKeyFile,
+        appInstallationId,
+      );
+    } else {
+      logger.info(
+        'No GitHub App installation ID detected. Defaulting to authenticating using an access token...',
+      );
+      return getTokenAuthConfig(accessToken);
+    }
+  } catch (e) {
+    logger.error('Error creating and validating auth config', e);
+    throw e;
+  }
+};

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -7,6 +7,7 @@ import { parse } from '@fast-csv/parse';
 import boxen from 'boxen';
 import semver from 'semver';
 import { PostHog } from 'posthog-node';
+import { createAuthConfig } from '../auth';
 
 import {
   actionRunner,
@@ -967,9 +968,35 @@ command
   .name('import')
   .version(VERSION)
   .description('Import a GitHub project')
-  .option(
-    '--access-token <access_token>',
-    'The access token used to interact with the GitHub API. This can also be set using the IMPORT_GITHUB_TOKEN environment variable.',
+  .addOption(
+    new Option(
+      '--access-token <access_token>',
+      'The access token used to interact with the GitHub API. This can also be set using the GITHUB_TOKEN environment variable.',
+    ).env('GITHUB_TOKEN'),
+  )
+  .addOption(
+    new Option(
+      '--app-installation-id <app_installation_id>',
+      'The installation ID of the GitHub App. If this is provided, the app ID and private key must also be provided.',
+    ).env('GITHUB_APP_INSTALLATION_ID'),
+  )
+  .addOption(
+    new Option(
+      '--app-id <app_id>',
+      'The App ID of the GitHub App. If this is provided, the installation ID and private key must also be provided.',
+    ).env('GITHUB_APP_ID'),
+  )
+  .addOption(
+    new Option(
+      '--private-key <private_key>',
+      'The private key of the GitHub App. Alternatively, use --private-key-file if you have a .pem file. If this is provided, the app ID and installation ID must also be provided.',
+    ).env('GITHUB_APP_PRIVATE_KEY'),
+  )
+  .addOption(
+    new Option(
+      '--private-key-file <private_key_file>',
+      'The private key of the GitHub App. For example, path to a *.pem file you downloaded from the about page of the GitHub App. If this is provided, the app ID and installation ID must also be provided.',
+    ).env('GITHUB_APP_PRIVATE_KEY_FILE'),
   )
   .option(
     '--base-url <base_url>',
@@ -1065,13 +1092,7 @@ command
         host: POSTHOG_HOST,
       });
 
-      const accessToken = accessTokenFromArguments || process.env.IMPORT_GITHUB_TOKEN;
-
-      if (!accessToken) {
-        throw new Error(
-          'You must specify a GitHub access token using the --access-token argument or IMPORT_GITHUB_TOKEN environment variable.',
-        );
-      }
+      const authConfig = createAuthConfig({ ...opts, logger: logger });
 
       if (!existsSync(inputPath)) {
         throw new Error(
@@ -1093,7 +1114,7 @@ command
 
       const baseUrl = normalizeBaseUrl(baseUrlFromArguments, logger);
 
-      const octokit = createOctokit(accessToken, baseUrl, proxyUrl, logger);
+      const octokit = createOctokit(authConfig, baseUrl, proxyUrl, logger);
 
       const shouldCheckRateLimitAgain = await logRateLimitInformation(logger, octokit);
 

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -2,13 +2,13 @@ import { STATUS_CODES } from 'http';
 import { fetch as undiciFetch, ProxyAgent, RequestInfo, RequestInit } from 'undici';
 import { Octokit, RequestError } from 'octokit';
 import { paginateGraphQL } from '@octokit/plugin-paginate-graphql';
-
+import { AuthConfig } from './auth';
 import { Logger } from './logger';
 
 const OctokitWithPaginateGraphQL = Octokit.plugin(paginateGraphQL);
 
 export const createOctokit = (
-  token: string | undefined,
+  authConfig: AuthConfig,
   baseUrl: string,
   proxyUrl: string | undefined,
   logger: Logger,
@@ -21,7 +21,8 @@ export const createOctokit = (
   };
 
   const octokit = new OctokitWithPaginateGraphQL({
-    auth: token,
+    auth: authConfig.auth,
+    authStrategy: authConfig.authStrategy,
     baseUrl,
     request: {
       fetch: customFetch,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,7 +90,12 @@ export const checkForUpdates = async (
   proxyUrl: string | undefined,
   logger: Logger,
 ): Promise<void> => {
-  const octokit = createOctokit(undefined, 'https://api.github.com', proxyUrl, logger);
+  const octokit = createOctokit(
+    { auth: undefined },
+    'https://api.github.com',
+    proxyUrl,
+    logger,
+  );
 
   try {
     const { data: release } = await octokit.rest.repos.getLatestRelease({


### PR DESCRIPTION
Porting the work of @scottluskcis from migration audit: https://github.com/timrogers/gh-migration-audit/pull/257, https://github.com/timrogers/gh-migration-audit/pull/264

> ## Summary
> This PR adds in support for authentication using a GitHub App installation and also the use of the createAppAuth authStrategy that is part of [auth-app.js](https://github.com/octokit/auth-app.js). Specifically, new options have been added that allow specifying an app-id, private-key, and app-installation-id as option to the audit-all, audit-repos, and audit-repo commands. This will create an octokit instance that is authenticated as an installation, with automated installation token refresh as noted in [Usage with Octokit](https://github.com/octokit/auth-app.js/?tab=readme-ov-file#usage-with-octokit).
> 
>This was necessary to take advantage of octokit automated installation token refresh. When running gh-migration-audit with a command like audit-all and it took longer than an hour the token would expire. Using an authStrategy of createAppAuth allows for the automatic token refresh and successful completion of the command for larger orgs.
> 
> See also notes available at [Choosing between a GitHub App or a personal access token](https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/deciding-when-to-build-a-github-app#choosing-between-a-github-app-or-a-personal-access-token). This process needed to be run periodically and did not need to be tied to a user account but rather a GitHub App instance.
> 
> NOTE: Original PR was reviewed https://github.com/scottluskcis/gh-migration-audit/pull/1, created another PR to have a squash commit and clean history.

> ## Changes
> - add new auth.ts file that handles creating the configuration passed to creation of an Octokit instance
update the options for the commands to optionally allow specification of the app-id, private-key, and app-installation-id
> - add tests for the auth.ts file added
> - add samples to the README for the new options and explanation in Authentication section
> - update octokit.ts to accept a string for token as it did before or an AuthConfig object, backwards compatible
> This pull request introduces significant changes to the authentication mechanism used in the repository audit tool. The most important changes include adding support for GitHub App installation authentication, updating the command options to accommodate the new authentication method, and refactoring the code to handle both token and installation authentication seamlessly.

> Documentation
> Updated README describing changes

> Usage
> New options displayed in `--help`, note addition of `--app-installation-id`, `--app-id`, and `--private-key`. Also note environment variable display for these and also for `--access-token`

<img width="1599" alt="Screenshot 2025-04-09 at 1 26 17 PM" src="https://github.com/user-attachments/assets/c5172472-a2bb-4538-a736-79b8d31d6405" />

Closes: #455